### PR TITLE
reverse pg8000 to stay at 1.16.4 to keep PGJsonb function

### DIFF
--- a/lambda/setup.py
+++ b/lambda/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 inst_reqs = [
     "mercantile",
-    "pg8000",
+    "pg8000==1.16.4",
     "requests",
     "pillow",
     "numpy"


### PR DESCRIPTION
`PGJson` and `PGjsonb` were [removed after PG8000 version 1.16.6](https://github.com/tlocke/pg8000#version-1166-2020-10-10). 
